### PR TITLE
feat: folder picker, batch run, run history, interactive favicon & UX improvements

### DIFF
--- a/app/api/run/route.ts
+++ b/app/api/run/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: cfgError }, { status: 500 });
   }
 
-  let body: { testCase?: unknown };
+  let body: { testCase?: unknown; headless?: unknown };
   try {
     body = await req.json();
   } catch {
@@ -25,11 +25,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "testCase is required" }, { status: 400 });
   }
 
+  const headless = body.headless !== false;
   const title = firstNonEmptyLine(testCase) || "Untitled test";
   const id = crypto.randomBytes(6).toString("hex");
-  createRun(id, title);
+  createRun(id, title, testCase);
 
-  runAgent(id, testCase).catch((err) => {
+  runAgent(id, testCase, headless).catch((err) => {
     console.error("agent crashed", err);
   });
 

--- a/app/api/runs/route.ts
+++ b/app/api/runs/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { listRuns } from "@/lib/store";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json(listRuns());
+}

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 8V4H8"/>
+  <rect width="16" height="12" x="4" y="8" rx="2"/>
+  <path d="M2 14h2"/>
+  <path d="M20 14h2"/>
+  <path d="M15 13v2"/>
+  <path d="M9 13v2"/>
+</svg>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,23 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
-import { Bot, FileText, ArrowRight, Upload } from "lucide-react";
+import { useRef, useState, useEffect } from "react";
+import Link from "next/link";
+import {
+  Bot, FileText, ArrowRight, Upload, Folder, X,
+  Check, CircleAlert, Clock, Loader2, Square, CheckSquare,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import type { RunStatus } from "@/lib/types";
+import { updateFavicon, resetFavicon } from "@/lib/favicon";
+
+type RunSummary = { id: string; createdAt: number; status: RunStatus; title: string };
+type MdFile = { name: string; file: File };
+type BatchItem = { file: MdFile; id: string | null; status: "queued" | "skipped" | RunStatus; startedAt?: number; finishedAt?: number };
+
+const ACTIVE = new Set(["running", "waiting", "paused"]);
 
 const EXAMPLE = `TC-001 — Login and add item to cart
 URL: https://www.saucedemo.com/
@@ -21,144 +33,507 @@ Steps:
 4. Click the cart icon.
    Expected: cart contains exactly one item — Sauce Labs Backpack at $29.99.`;
 
+// persists across route transitions within the same tab
+let _text = "";
+let _mdFiles: MdFile[] = [];
+let _selectedFile: string | null = null;
+let _checkedFiles: Set<string> = new Set();
+let _batchItems: BatchItem[] = [];
+let _batchRunning = false;
+let _batchAbort = false;
+let _batchCurrentId: string | null = null;
+let _batchStartedAt: number | null = null;
+let _batchFinishedAt: number | null = null;
+
 export default function Home() {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [text, setText] = useState("");
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
+  const [text, setText] = useState(_text);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [focused, setFocused] = useState(false);
+  const [mdFiles, setMdFiles] = useState<MdFile[]>(_mdFiles);
+  const [selectedFile, setSelectedFile] = useState<string | null>(_selectedFile);
+  const [history, setHistory] = useState<RunSummary[]>([]);
+
+  // batch
+  const [checkedFiles, setCheckedFiles] = useState<Set<string>>(_checkedFiles);
+  const [batchItems, setBatchItems] = useState<BatchItem[]>(_batchItems);
+  const [batchRunning, setBatchRunning] = useState(_batchRunning);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!batchRunning) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [batchRunning]);
+
+  useEffect(() => {
+    fetch("/api/runs").then(r => r.ok ? r.json() : []).then(setHistory).catch(() => {});
+  }, []);
+
+  // sync batch state from module-level vars when re-mounting mid-batch
+  useEffect(() => {
+    if (!_batchRunning) return;
+    const t = setInterval(() => {
+      setBatchItems([..._batchItems]);
+      setBatchRunning(_batchRunning);
+      if (!_batchRunning) clearInterval(t);
+    }, 200);
+    return () => clearInterval(t);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // favicon: spin while batch running, show result when done
+  useEffect(() => {
+    if (batchRunning) {
+      updateFavicon("running");
+    } else if (_batchItems.length > 0) {
+      const hasError = _batchItems.some(it => it.status === "failed" || it.status === "error");
+      const allPassed = _batchItems.every(it => it.status === "passed");
+      updateFavicon(hasError ? "failed" : allPassed ? "passed" : "default");
+    }
+  }, [batchRunning]);
+
+  useEffect(() => () => { resetFavicon(); }, []);
+
+  function setTextSaved(v: string) { _text = v; setText(v); }
+  function setMdFilesSaved(v: MdFile[]) { _mdFiles = v; setMdFiles(v); }
+  function setSelectedFileSaved(v: string | null) { _selectedFile = v; setSelectedFile(v); }
+  function setCheckedFilesSaved(v: Set<string>) { _checkedFiles = v; setCheckedFiles(v); }
+  function setBatchItemsSaved(v: BatchItem[] | ((prev: BatchItem[]) => BatchItem[])) {
+    const next = typeof v === "function" ? v(_batchItems) : v;
+    _batchItems = next;
+    setBatchItems([...next]);
+  }
+  function setBatchRunningSaved(v: boolean) { _batchRunning = v; setBatchRunning(v); }
 
   function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
     const reader = new FileReader();
     reader.onload = (ev) => {
-      const content = ev.target?.result;
-      if (typeof content === "string") setText(content);
+      if (typeof ev.target?.result === "string") setTextSaved(ev.target.result);
     };
     reader.readAsText(file, "utf-8");
     e.target.value = "";
   }
 
-  async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault();
+  function onFolderChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const all = Array.from(e.target.files ?? []);
+    const files: MdFile[] = all
+      .filter(f => f.name.endsWith(".md"))
+      .map(f => ({ name: (f as any).webkitRelativePath || f.name, file: f }));
+    files.sort((a, b) => a.name.localeCompare(b.name));
+    setMdFilesSaved(files);
+    setSelectedFileSaved(null);
+    setCheckedFilesSaved(new Set());
+    setBatchItemsSaved([]);
+    e.target.value = "";
+  }
+
+  async function onSelectFile(f: MdFile) {
+    const content = await f.file.text();
+    setTextSaved(content);
+    setSelectedFileSaved(f.name);
+  }
+
+  function toggleCheck(name: string) {
+    const next = new Set(checkedFiles);
+    next.has(name) ? next.delete(name) : next.add(name);
+    setCheckedFilesSaved(next);
+  }
+
+  function toggleAll() {
+    setCheckedFilesSaved(
+      checkedFiles.size === mdFiles.length ? new Set() : new Set(mdFiles.map(f => f.name))
+    );
+  }
+
+  // ── single run ───────────────────────────────────────────────────────────────
+
+  async function createRunApi(content: string, headless: boolean): Promise<string> {
+    const res = await fetch("/api/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ testCase: content, headless }),
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || "error");
+    return json.id;
+  }
+
+  async function startRun(headless: boolean) {
     if (!text.trim()) return;
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch("/api/run", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ testCase: text }),
-      });
-      const json = await res.json();
-      if (!res.ok) throw new Error(json.error || "error");
-      router.push(`/run/${json.id}`);
+      const id = await createRunApi(text, headless);
+      router.push(`/run/${id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
       setBusy(false);
     }
   }
 
+  function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault();
+    startRun(true);
+  }
+
+  // ── batch run ────────────────────────────────────────────────────────────────
+
+  function waitForRun(id: string): Promise<RunStatus | "skipped"> {
+    return new Promise(resolve => {
+      const es = new EventSource(`/api/run/${id}/stream`);
+
+      const pollAbort = setInterval(() => {
+        if (_batchAbort) {
+          clearInterval(pollAbort);
+          es.close();
+          resolve("paused");
+        }
+      }, 150);
+
+      es.onmessage = msg => {
+        const data = JSON.parse(msg.data);
+        const status: RunStatus = data.run?.status;
+        if (_batchAbort) { clearInterval(pollAbort); es.close(); resolve("paused"); return; }
+        if (status && !ACTIVE.has(status)) { clearInterval(pollAbort); es.close(); resolve(status); }
+      };
+      es.onerror = () => { clearInterval(pollAbort); es.close(); resolve("error"); };
+    });
+  }
+
+  async function stopBatch() {
+    _batchAbort = true;
+    const id = _batchCurrentId;
+    if (id) {
+      fetch(`/api/run/${id}/pause`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "pause" }),
+      }).catch(() => {});
+    }
+  }
+
+  async function runBatch(headless: boolean) {
+    const toRun = mdFiles.filter(f => checkedFiles.has(f.name));
+    if (!toRun.length) return;
+
+    const items: BatchItem[] = toRun.map(f => ({ file: f, id: null, status: "queued" }));
+    setBatchItemsSaved(items);
+    setBatchRunningSaved(true);
+    _batchAbort = false;
+    _batchCurrentId = null;
+    _batchStartedAt = Date.now();
+    _batchFinishedAt = null;
+
+    for (let i = 0; i < items.length; i++) {
+      if (_batchAbort) {
+        setBatchItemsSaved(prev => prev.map((it, idx) => idx >= i ? { ...it, status: "skipped" } : it));
+        break;
+      }
+
+      const itemStart = Date.now();
+      setBatchItemsSaved(prev => prev.map((it, idx) => idx === i ? { ...it, status: "running", startedAt: itemStart } : it));
+
+      try {
+        const content = await items[i].file.file.text();
+        const id = await createRunApi(content, headless);
+        _batchCurrentId = id;
+        setBatchItemsSaved(prev => prev.map((it, idx) => idx === i ? { ...it, id } : it));
+        const finalStatus = await waitForRun(id);
+        const itemEnd = Date.now();
+        setBatchItemsSaved(prev => prev.map((it, idx) => idx === i ? { ...it, status: finalStatus, finishedAt: itemEnd } : it));
+        if (_batchAbort) {
+          setBatchItemsSaved(prev => prev.map((it, idx) => idx > i ? { ...it, status: "skipped" } : it));
+          break;
+        }
+      } catch {
+        setBatchItemsSaved(prev => prev.map((it, idx) => idx === i ? { ...it, status: "error", finishedAt: Date.now() } : it));
+      }
+    }
+
+    _batchCurrentId = null;
+    _batchFinishedAt = Date.now();
+    setBatchRunningSaved(false);
+    fetch("/api/runs").then(r => r.ok ? r.json() : []).then(setHistory).catch(() => {});
+  }
+
+  const checkedCount = checkedFiles.size;
+  const allChecked = mdFiles.length > 0 && checkedFiles.size === mdFiles.length;
+
   return (
     <main className="flex flex-col items-center min-h-screen px-6 pt-20 pb-24">
-      {/* logo mark */}
       <div className="flex items-center justify-center size-11 rounded-2xl border border-white/10 bg-white/5 mb-6 shadow-lg">
         <Bot className="size-5 text-foreground/80" />
       </div>
 
-      {/* heading */}
       <h1 className="text-3xl font-semibold tracking-tight mb-2">QA Agent</h1>
-      <p className="text-sm text-muted-foreground mb-10">
-        Paste a test case. Watch it run.
-      </p>
+      <p className="text-sm text-muted-foreground mb-10">Paste a test case. Watch it run.</p>
 
-      {/* form */}
-      <form
-        ref={formRef}
-        onSubmit={onSubmit}
-        className="w-full max-w-2xl space-y-3"
-      >
-        <div
-          className={cn(
-            "rounded-xl border transition-all duration-200",
-            focused
-              ? "border-white/15 shadow-[0_0_0_3px_oklch(0.5_0.1_270_/_12%)]"
-              : "border-white/7",
-          )}
-        >
-          <Textarea
-            placeholder="Paste your test case here…"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
-            onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                e.preventDefault();
-                formRef.current?.requestSubmit();
-              }
-            }}
-            rows={16}
-            className="min-h-[320px] font-mono text-[12.5px] leading-relaxed resize-none border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 rounded-xl p-4"
-          />
-        </div>
+      <div className="w-full max-w-2xl space-y-3">
 
+        {/* folder picker */}
         <div className="flex items-center gap-2">
-          <Button
-            type="submit"
-            disabled={!text.trim() || busy}
-            size="lg"
-            className="gap-2 font-medium"
-          >
-            {busy ? (
-              "Running…"
-            ) : (
-              <>
-                Run
-                <ArrowRight className="size-4" />
-              </>
-            )}
+          <input ref={folderInputRef} type="file"
+            // @ts-ignore
+            webkitdirectory="" multiple className="hidden" onChange={onFolderChange} />
+          <input ref={fileInputRef} type="file" accept=".md,text/markdown"
+            className="hidden" onChange={onFileChange} />
+          <Button type="button" variant="outline" size="sm"
+            onClick={() => folderInputRef.current?.click()}
+            className="gap-2 text-muted-foreground hover:text-foreground">
+            <Folder className="size-4" />Choose folder
           </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="lg"
-            onClick={() => setText(EXAMPLE)}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <FileText className="size-4" />
-            Example
-          </Button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".md,text/markdown"
-            className="hidden"
-            onChange={onFileChange}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="lg"
+          <Button type="button" variant="outline" size="sm"
             onClick={() => fileInputRef.current?.click()}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <Upload className="size-4" />
-            Upload .md
+            className="gap-2 text-muted-foreground hover:text-foreground">
+            <Upload className="size-4" />Upload .md
           </Button>
 
-          {error && (
-            <span className="text-destructive text-xs ml-1">{error}</span>
+          {mdFiles.length > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {mdFiles.length} .md file{mdFiles.length !== 1 ? "s" : ""} found
+            </span>
           )}
 
-          <kbd className="ml-auto hidden sm:inline-flex items-center gap-1 rounded-md border border-border bg-muted/30 px-2 py-1 text-[10px] font-mono text-muted-foreground/60">
-            ⌘ + ↵
-          </kbd>
+          {mdFiles.length > 0 && (
+            <Button type="button" variant="ghost" size="sm"
+              onClick={() => { setMdFilesSaved([]); setSelectedFileSaved(null); setCheckedFilesSaved(new Set()); setBatchItemsSaved([]); }}
+              className="ml-auto text-muted-foreground hover:text-foreground p-1 h-auto">
+              <X className="size-3.5" />
+            </Button>
+          )}
         </div>
-      </form>
+
+        {/* file list */}
+        {mdFiles.length > 0 && (
+          <>
+            <ul className="rounded-xl border border-white/7 divide-y divide-white/5 overflow-hidden">
+              {/* select-all row */}
+              <li>
+                <div className="flex items-center gap-3 px-4 py-2 bg-white/[0.02]">
+                  <button type="button" onClick={toggleAll}
+                    className="shrink-0 text-muted-foreground/50 hover:text-foreground transition-colors">
+                    {allChecked
+                      ? <CheckSquare className="size-4 text-foreground/70" />
+                      : <Square className="size-4" />}
+                  </button>
+                  <span className="text-[11px] text-muted-foreground/50 select-none">
+                    {checkedCount > 0 ? `${checkedCount} selected` : "Select all"}
+                  </span>
+
+                  {checkedCount > 0 && !batchRunning && (
+                    <div className="ml-auto flex items-center gap-1.5">
+                      <Button type="button" size="sm"
+                        className="h-7 gap-1.5 text-xs font-medium"
+                        onClick={() => runBatch(true)}>
+                        <ArrowRight className="size-3.5" />
+                        Run {checkedCount}
+                      </Button>
+                      <Button type="button" size="sm" variant="secondary"
+                        className="h-7 gap-1.5 text-xs"
+                        onClick={() => runBatch(false)}>
+                        <ArrowRight className="size-3.5" />
+                        With preview
+                      </Button>
+                    </div>
+                  )}
+
+                  {batchRunning && (
+                    <div className="ml-auto flex items-center gap-2">
+                      <Loader2 className="size-3.5 text-muted-foreground/50 animate-spin" />
+                      <Button type="button" size="sm" variant="ghost"
+                        className="h-7 text-xs text-destructive hover:text-destructive"
+                        onClick={stopBatch}>
+                        Stop
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </li>
+
+              {mdFiles.map(f => (
+                <li key={f.name} className="flex items-center">
+                  <button type="button" onClick={() => toggleCheck(f.name)}
+                    className="shrink-0 px-4 py-2.5 text-muted-foreground/50 hover:text-foreground transition-colors">
+                    {checkedFiles.has(f.name)
+                      ? <CheckSquare className="size-4 text-foreground/70" />
+                      : <Square className="size-4" />}
+                  </button>
+                  <button type="button" onClick={() => onSelectFile(f)}
+                    className={cn(
+                      "flex-1 text-left py-2.5 pr-4 text-sm font-mono transition-colors truncate",
+                      selectedFile === f.name
+                        ? "text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}>
+                    {f.name}
+                  </button>
+                </li>
+              ))}
+            </ul>
+
+            {/* batch progress */}
+            {batchItems.length > 0 && (
+              <div className="rounded-xl border border-white/7 overflow-hidden">
+                <div className="px-4 py-2.5 bg-white/[0.02] flex items-center gap-2">
+                  <span className="text-[10.5px] font-semibold uppercase tracking-widest text-muted-foreground/40">
+                    Batch run
+                  </span>
+                  {_batchStartedAt && (
+                    <span className="ml-auto text-[11px] font-mono tabular-nums text-muted-foreground/40">
+                      {formatDur((_batchFinishedAt ?? now) - _batchStartedAt)}
+                    </span>
+                  )}
+                </div>
+                <ul className="divide-y divide-white/5">
+                  {batchItems.map((item, i) => (
+                    <li key={i} className="flex items-center gap-3 px-4 py-2.5">
+                      <BatchStatusIcon status={item.status} />
+                      {item.id
+                        ? <Link href={`/run/${item.id}`}
+                            className="flex-1 min-w-0 text-sm font-mono text-foreground/70 hover:text-foreground truncate transition-colors">
+                            {item.file.name}
+                          </Link>
+                        : <span className="flex-1 min-w-0 text-sm font-mono text-muted-foreground/40 truncate">
+                            {item.file.name}
+                          </span>
+                      }
+                      <span className="shrink-0 text-[11px] font-mono tabular-nums text-muted-foreground/30">
+                        {item.startedAt
+                          ? formatDur((item.finishedAt ?? (item.status === "running" ? now : item.startedAt)) - item.startedAt)
+                          : ""}
+                      </span>
+                      {item.status !== "queued" && item.status !== "running" && item.status !== "skipped" && (
+                        <span className={cn(
+                          "shrink-0 text-[10.5px] font-semibold uppercase tracking-wide",
+                          item.status === "passed" ? "text-success" :
+                          item.status === "failed" || item.status === "error" ? "text-destructive" :
+                          "text-muted-foreground/40"
+                        )}>
+                          {item.status}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* form */}
+        <form ref={formRef} onSubmit={onSubmit} className="space-y-3">
+          <div className={cn(
+            "rounded-xl border transition-all duration-200",
+            focused ? "border-white/15 shadow-[0_0_0_3px_oklch(0.5_0.1_270_/_12%)]" : "border-white/7",
+          )}>
+            <Textarea
+              placeholder="Paste your test case here…"
+              value={text}
+              onChange={e => setTextSaved(e.target.value)}
+              onFocus={() => setFocused(true)}
+              onBlur={() => setFocused(false)}
+              onKeyDown={e => {
+                if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                  e.preventDefault();
+                  formRef.current?.requestSubmit();
+                }
+              }}
+              rows={16}
+              className="min-h-[320px] font-mono text-[12.5px] leading-relaxed resize-none border-0 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 rounded-xl p-4"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button type="submit" disabled={!text.trim() || busy} size="lg" className="gap-2 font-medium">
+              {busy ? "Running…" : <><ArrowRight className="size-4" />Run</>}
+            </Button>
+            <Button type="button" disabled={!text.trim() || busy} size="lg" variant="secondary"
+              onClick={() => startRun(false)} className="gap-2">
+              {busy ? "Running…" : <><ArrowRight className="size-4" />Run with preview</>}
+            </Button>
+            <Button type="button" variant="ghost" size="lg"
+              onClick={() => setTextSaved(EXAMPLE)}
+              className="text-muted-foreground hover:text-foreground">
+              <FileText className="size-4" />Example
+            </Button>
+
+            {error && <span className="text-destructive text-xs ml-1">{error}</span>}
+
+            <kbd className="ml-auto hidden sm:inline-flex items-center gap-1 rounded-md border border-border bg-muted/30 px-2 py-1 text-[10px] font-mono text-muted-foreground/60">
+              ⌘ + ↵
+            </kbd>
+          </div>
+        </form>
+      </div>
+
+      {/* history */}
+      {history.length > 0 && (
+        <div className="w-full max-w-2xl mt-12">
+          <div className="text-[10.5px] font-semibold uppercase tracking-widest text-muted-foreground/40 mb-3">
+            Recent runs
+          </div>
+          <ul className="space-y-1.5">
+            {history.map(run => (
+              <li key={run.id}>
+                <Link href={`/run/${run.id}`}
+                  className="flex items-center gap-3 rounded-xl border border-white/7 px-4 py-3 hover:bg-white/5 transition-colors">
+                  <RunStatusIcon status={run.status} />
+                  <span className="flex-1 min-w-0 text-sm text-foreground/80 truncate">{run.title}</span>
+                  <span className="shrink-0 text-[11px] text-muted-foreground/40 font-mono tabular-nums">
+                    {formatTime(run.createdAt)}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </main>
   );
+}
+
+function BatchStatusIcon({ status }: { status: "queued" | "skipped" | RunStatus }) {
+  if (status === "running")
+    return <Loader2 className="size-3.5 shrink-0 text-muted-foreground/50 animate-spin" />;
+  if (status === "passed")
+    return <Check className="size-3.5 shrink-0 text-success" strokeWidth={2.5} />;
+  if (status === "failed" || status === "error")
+    return <CircleAlert className="size-3.5 shrink-0 text-destructive" />;
+  if (status === "paused")
+    return <span className="size-3.5 shrink-0 text-[10px] text-muted-foreground/40 font-mono">▐▐</span>;
+  if (status === "skipped")
+    return <span className="size-3.5 shrink-0 text-[10px] text-muted-foreground/30 font-mono">—</span>;
+  return <span className="size-3.5 shrink-0 rounded-sm border border-white/15 inline-block" />;
+}
+
+function RunStatusIcon({ status }: { status: RunStatus }) {
+  if (status === "passed")
+    return <Check className="size-3.5 shrink-0 text-success" strokeWidth={2.5} />;
+  if (status === "failed" || status === "error")
+    return <CircleAlert className="size-3.5 shrink-0 text-destructive" />;
+  return <Clock className="size-3.5 shrink-0 text-muted-foreground/40" />;
+}
+
+function formatDur(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const today = new Date();
+  const isToday = d.getDate() === today.getDate()
+    && d.getMonth() === today.getMonth()
+    && d.getFullYear() === today.getFullYear();
+  return isToday
+    ? d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+    : d.toLocaleDateString([], { month: "short", day: "numeric" }) + " " +
+      d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
-import { Bot, FileText, ArrowRight } from "lucide-react";
+import { Bot, FileText, ArrowRight, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -24,10 +24,23 @@ Steps:
 export default function Home() {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [focused, setFocused] = useState(false);
+
+  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const content = ev.target?.result;
+      if (typeof content === "string") setText(content);
+    };
+    reader.readAsText(file, "utf-8");
+    e.target.value = "";
+  }
 
   async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -118,6 +131,23 @@ export default function Home() {
           >
             <FileText className="size-4" />
             Example
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".md,text/markdown"
+            className="hidden"
+            onChange={onFileChange}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="lg"
+            onClick={() => fileInputRef.current?.click()}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <Upload className="size-4" />
+            Upload .md
           </Button>
 
           {error && (

--- a/app/run/[id]/page.tsx
+++ b/app/run/[id]/page.tsx
@@ -21,6 +21,7 @@ import type {
   RunEvent,
   StepResult,
 } from "@/lib/types";
+import { updateFavicon, resetFavicon } from "@/lib/favicon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -110,6 +111,18 @@ export default function RunPage({ params }: PageProps) {
   }, [isRunning]);
 
   useEffect(() => {
+    updateFavicon(status);
+    return () => { resetFavicon(); };
+  }, [status]);
+
+  useEffect(() => {
+    if (!run?.title) return;
+    const prev = document.title;
+    document.title = run.title;
+    return () => { document.title = prev; };
+  }, [run?.title]);
+
+  useEffect(() => {
     if (activeStepNum == null) return;
     document
       .getElementById(`step-${activeStepNum}`)
@@ -153,7 +166,7 @@ export default function RunPage({ params }: PageProps) {
         className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-8"
       >
         <ArrowLeft className="size-3.5" />
-        new run
+        Back
       </Link>
 
       {/* status header */}
@@ -253,6 +266,26 @@ export default function RunPage({ params }: PageProps) {
           </div>
           <div className="text-sm leading-relaxed text-foreground/80">{run.summary}</div>
         </div>
+      )}
+
+      {/* test case instruction */}
+      {run?.testCase && (
+        <Collapsible className="mt-3">
+          <div className="rounded-xl border border-white/7 bg-card/60 overflow-hidden">
+            <CollapsibleTrigger className="group w-full flex items-center justify-between px-4 py-3 hover:bg-white/[0.02] transition-colors">
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/40">
+                Test case
+              </span>
+              <ChevronRight className="size-3.5 text-muted-foreground/30 group-data-open:hidden" />
+              <ChevronDown className="size-3.5 text-muted-foreground/30 hidden group-data-open:inline" />
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <pre className="px-4 pb-4 text-[11.5px] font-mono leading-relaxed text-foreground/60 whitespace-pre-wrap break-words border-t border-white/5 pt-3">
+                {run.testCase}
+              </pre>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
       )}
 
       {/* star CTA — show once a run has finished (the "you just saw it work" moment) */}

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,4 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { spawn } from "node:child_process";
 import { chromium, type Browser, type Locator, type Page } from "playwright";
 import { askQuestion, checkPause, pushEvent, saveScreenshot, setPlan } from "./store";
 import { TOOLS, snapshot } from "./tools";
@@ -475,6 +476,8 @@ export async function runAgent(
 ): Promise<void> {
   let browser: Browser | null = null;
 
+  const wakeLock = spawnWakeLock();
+
   const cfg = resolveProvider();
   const client =
     cfg.kind === "anthropic"
@@ -617,5 +620,30 @@ export async function runAgent(
     pushEvent(runId, { ts: Date.now(), kind: "error", text: message });
   } finally {
     await browser?.close().catch(() => {});
+    wakeLock?.kill();
   }
+}
+
+function spawnWakeLock() {
+  try {
+    if (process.platform === "darwin") {
+      return spawn("caffeinate", ["-i"], { stdio: "ignore" });
+    }
+    if (process.platform === "win32") {
+      // Calls SetThreadExecutionState(ES_CONTINUOUS|ES_SYSTEM_REQUIRED) every 30s.
+      // When the process is killed the OS automatically clears the requirement.
+      const ps = `Add-Type -Name K -Namespace W -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint f);'; while($true){[W.K]::SetThreadExecutionState(0x80000003); Start-Sleep 30}`;
+      return spawn("powershell", ["-NonInteractive", "-Command", ps], { stdio: "ignore" });
+    }
+    if (process.platform === "linux") {
+      return spawn(
+        "systemd-inhibit",
+        ["--what=sleep:idle", "--who=qpilot", "--why=Running test", "--mode=block", "sleep", "infinity"],
+        { stdio: "ignore" },
+      );
+    }
+  } catch {
+    // wake lock is best-effort — ignore if unavailable
+  }
+  return null;
 }

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -471,6 +471,7 @@ async function callModel(
 export async function runAgent(
   runId: string,
   testCase: string,
+  headless = true,
 ): Promise<void> {
   let browser: Browser | null = null;
 
@@ -483,7 +484,7 @@ export async function runAgent(
   try {
     browser = await chromium.launch({
       channel: "chrome",
-      headless: process.env.HEADLESS !== "false",
+      headless,
     });
     const context = await browser.newContext({
       viewport: { width: 1440, height: 900 },

--- a/lib/favicon.ts
+++ b/lib/favicon.ts
@@ -1,0 +1,74 @@
+const BOT = `<path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>`;
+
+function svg(stroke: string, badge = "") {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="${stroke}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${BOT}${badge}</svg>`;
+}
+
+function toUrl(s: string) {
+  return `data:image/svg+xml,${encodeURIComponent(s)}`;
+}
+
+function setHref(url: string) {
+  let el = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  if (!el) {
+    el = Object.assign(document.createElement("link"), { rel: "icon" });
+    document.head.appendChild(el);
+  }
+  el.href = url;
+}
+
+function statusSvg(content: string) {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">${content}</svg>`;
+}
+
+// 10 frames × 100ms = 1 rotation per second, matched to browser favicon refresh rate
+const SPINNER_N = 10;
+const SPINNER_FRAMES = Array.from({ length: SPINNER_N }, (_, i) => {
+  const a = (i / SPINNER_N) * Math.PI * 2 - Math.PI / 2;
+  const sweep = Math.PI * 0.65;
+  const r = 10;
+  const cx = 12, cy = 12;
+  const x1 = cx + r * Math.cos(a);
+  const y1 = cy + r * Math.sin(a);
+  const x2 = cx + r * Math.cos(a + sweep);
+  const y2 = cy + r * Math.sin(a + sweep);
+  const content =
+    `<circle cx="12" cy="12" r="10" stroke="#38bdf8" stroke-width="2.5" fill="none" opacity="0.15"/>` +
+    `<path d="M${x1.toFixed(3)} ${y1.toFixed(3)} A10 10 0 0 1 ${x2.toFixed(3)} ${y2.toFixed(3)}" stroke="#38bdf8" stroke-width="2.5" fill="none" stroke-linecap="round"/>`;
+  return toUrl(statusSvg(content));
+});
+
+const STATUS_ICONS: Record<string, string> = {
+  passed:  toUrl(statusSvg(`<circle cx="12" cy="12" r="10" fill="#22c55e"/><path d="M7 12.5l3.5 3.5 6.5-7" stroke="white" stroke-width="2.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>`)),
+  failed:  toUrl(statusSvg(`<circle cx="12" cy="12" r="10" fill="#ef4444"/><path d="M8 8l8 8M16 8l-8 8" stroke="white" stroke-width="2.2" stroke-linecap="round"/>`)),
+  error:   toUrl(statusSvg(`<circle cx="12" cy="12" r="10" fill="#ef4444"/><path d="M8 8l8 8M16 8l-8 8" stroke="white" stroke-width="2.2" stroke-linecap="round"/>`)),
+  waiting: toUrl(statusSvg(`<circle cx="12" cy="12" r="10" fill="#facc15"/><path d="M12 7v5.5l3 3" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>`)),
+  paused:  toUrl(statusSvg(`<circle cx="12" cy="12" r="10" fill="#64748b"/><path d="M9 8v8M15 8v8" stroke="white" stroke-width="2.2" stroke-linecap="round"/>`)),
+  default: toUrl(svg("white")),
+};
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let frame = 0;
+
+function stopTimer() {
+  if (timer) { clearInterval(timer); timer = null; }
+}
+
+export function updateFavicon(status: string) {
+  stopTimer();
+  if (status === "running") {
+    frame = 0;
+    setHref(SPINNER_FRAMES[0]);
+    timer = setInterval(() => {
+      frame = (frame + 1) % SPINNER_N;
+      setHref(SPINNER_FRAMES[frame]);
+    }, 100);
+    return;
+  }
+  setHref(STATUS_ICONS[status] ?? STATUS_ICONS.default);
+}
+
+export function resetFavicon() {
+  stopTimer();
+  setHref(STATUS_ICONS.default);
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -17,16 +17,21 @@ const g = globalThis as unknown as { __qa_entries?: Map<string, Entry> };
 const entries = (g.__qa_entries ??= new Map<string, Entry>());
 
 const ACTIVE = new Set(["running", "waiting", "paused"]);
+const MAX_HISTORY = 50;
 
-export function createRun(id: string, title: string): Run {
-  for (const [k, e] of entries) {
-    if (!ACTIVE.has(e.run.status)) entries.delete(k);
-  }
+export function createRun(id: string, title: string, testCase = ""): Run {
+  // keep at most MAX_HISTORY finished runs
+  const finished = [...entries.entries()].filter(([, e]) => !ACTIVE.has(e.run.status));
+  finished
+    .sort(([, a], [, b]) => a.run.createdAt - b.run.createdAt)
+    .slice(0, Math.max(0, finished.length - MAX_HISTORY + 1))
+    .forEach(([k]) => entries.delete(k));
   const run: Run = {
     id,
     createdAt: Date.now(),
     status: "running",
     title,
+    testCase,
     events: [],
     steps: [],
     pending: null,
@@ -43,6 +48,12 @@ export function createRun(id: string, title: string): Run {
 
 export function getRun(id: string): Run | undefined {
   return entries.get(id)?.run;
+}
+
+export function listRuns(): Pick<Run, "id" | "createdAt" | "status" | "title">[] {
+  return [...entries.values()]
+    .map(({ run }) => ({ id: run.id, createdAt: run.createdAt, status: run.status, title: run.title }))
+    .sort((a, b) => b.createdAt - a.createdAt);
 }
 
 export function setPlan(id: string, groups: PlanGroup[]): void {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -52,6 +52,7 @@ export interface Run {
   createdAt: number;
   status: RunStatus;
   title: string;
+  testCase: string;
   events: RunEvent[];
   steps: StepResult[];
   summary?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript": "^5.7.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20.12"
       }
     },
     "node_modules/@alloc/quick-lru": {


### PR DESCRIPTION
- Folder picker — выбор папки с .md файлами, список тест-кейсов
- Batch run — чекбоксы, последовательный запуск, прогресс-панель с таймерами, кнопка Stop
- Run history — GET /api/runs, список последних 50 запусков на главной странице
- Два режима запуска — headless и с видимым браузером (отдельные кнопки)
- Улучшения страницы запуска — коллапсируемая инструкция, кнопка Back, сохранение состояния
- Заголовок вкладки — имя теста в <title> на странице запуска
- Интерактивный favicon (lib/favicon.ts) — спиннер при активном тесте, иконки статуса для passed/failed/error/paused, SVG-робот как дефолт
- Отключение ухода в сон устройства Mac/Windows/Linux при работающих тестах