### PR TITLE
1. feat: prevent system sleep while a test is running

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,4 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
+import { spawn } from "node:child_process";
 import { chromium, type Browser, type Locator, type Page } from "playwright";
 import { askQuestion, checkPause, getRun, pushEvent, saveScreenshot, setPlan } from "./store";
 import { TOOLS, findAnchor, snapshot } from "./tools";
@@ -537,6 +538,8 @@ export async function runAgent(
 ): Promise<void> {
   let browser: Browser | null = null;
 
+  const wakeLock = spawnWakeLock();
+
   const cfg = resolveProvider();
   const client =
     cfg.kind === "anthropic"
@@ -711,5 +714,30 @@ export async function runAgent(
     pushEvent(runId, { ts: Date.now(), kind: "error", text: message });
   } finally {
     await browser?.close().catch(() => {});
+    wakeLock?.kill();
   }
+}
+
+function spawnWakeLock() {
+  try {
+    if (process.platform === "darwin") {
+      return spawn("caffeinate", ["-i"], { stdio: "ignore" });
+    }
+    if (process.platform === "win32") {
+      // Calls SetThreadExecutionState(ES_CONTINUOUS|ES_SYSTEM_REQUIRED) every 30s.
+      // When the process is killed the OS automatically clears the requirement.
+      const ps = `Add-Type -Name K -Namespace W -MemberDefinition '[DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint f);'; while($true){[W.K]::SetThreadExecutionState(0x80000003); Start-Sleep 30}`;
+      return spawn("powershell", ["-NonInteractive", "-Command", ps], { stdio: "ignore" });
+    }
+    if (process.platform === "linux") {
+      return spawn(
+        "systemd-inhibit",
+        ["--what=sleep:idle", "--who=qpilot", "--why=Running test", "--mode=block", "sleep", "infinity"],
+        { stdio: "ignore" },
+      );
+    }
+  } catch {
+    // wake lock is best-effort — ignore if unavailable
+  }
+  return null;
 }


### PR DESCRIPTION
Spawns a platform-specific wake-lock process at the start of each agent run and kills it in the finally block:
- macOS: caffeinate -i
- Windows: PowerShell loop calling SetThreadExecutionState(ES_SYSTEM_REQUIRED)
- Linux: systemd-inhibit

Failures are silently ignored so the test still runs on systems where the utility is unavailable.